### PR TITLE
Proteger deploy FTP por escopo publicado

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,6 +19,7 @@ on:
   pull_request:
     paths:
       - ".github/workflows/deploy.yml"
+      - "scripts/deploy/**"
       - "tests/deploy/**"
       - "docs/deploy-protection/**"
 
@@ -53,6 +54,9 @@ jobs:
           npx --yes esbuild src/css/branct.css --minify --allow-overwrite --outfile=src/css/branct.css || echo "minify branct.css falhou - segue sem minificar"
           npx --yes esbuild src/js/branct.js --minify --allow-overwrite --outfile=src/js/branct.js || echo "minify branct.js falhou - segue sem minificar"
           npx --yes esbuild src/js/trial.js --minify --allow-overwrite --outfile=src/js/trial.js || echo "minify trial.js falhou - segue sem minificar"
+
+      - name: Construir payload fechado
+        run: node scripts/deploy/build-publish-payload.mjs --source . --output "${RUNNER_TEMP}/branct-publish"
 
       - name: Instalar lftp
         run: sudo apt-get update && sudo apt-get install -y lftp
@@ -96,7 +100,7 @@ jobs:
               --exclude ^GEMINI-FIXES-APPLIED\.md$ \
               --exclude ^MELHORIAS-SUGERIDAS\.md$ \
               --exclude ^MOCKUP-IMPLEMENTATION\.md$ \
-              ./ /domains/branct.com/public_html/;
+              "${RUNNER_TEMP}/branct-publish/" /domains/branct.com/public_html/;
             quit
           "
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,17 @@ on:
   workflow_dispatch:
   pull_request:
     paths:
+      - "*.html"
+      - ".htaccess"
+      - "robots.txt"
+      - "sitemap.xml"
+      - "src/css/**"
+      - "src/js/**"
+      - "src/fonts/**"
+      - "src/i18n/**"
+      - "src/img/**"
       - ".github/workflows/deploy.yml"
+      - "deploy/publish-manifest.json"
       - "scripts/deploy/**"
       - "tests/deploy/**"
       - "docs/deploy-protection/**"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,15 +4,47 @@ on:
   push:
     branches:
       - main
+    paths:
+      - "*.html"
+      - ".htaccess"
+      - "robots.txt"
+      - "sitemap.xml"
+      - "src/css/**"
+      - "src/js/**"
+      - "src/fonts/**"
+      - "src/i18n/**"
+      - "src/img/**"
+      - "!src/img/video.mp4"
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - ".github/workflows/deploy.yml"
+      - "tests/deploy/**"
+      - "docs/deploy-protection/**"
 
 jobs:
+  verify-scope:
+    name: Verificar escopo do deploy
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout do codigo
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - name: Preparar Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 22
+      - name: Executar matriz offline
+        run: node --test tests/deploy/deploy-scope.test.mjs
+
   deploy:
     name: Deploy via FTP
+    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout do codigo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       # O repo fica legivel; so a copia enviada por FTP e minificada.
       # Se a minificacao falhar, o deploy segue com os ficheiros originais.

--- a/deploy/publish-manifest.json
+++ b/deploy/publish-manifest.json
@@ -1,0 +1,11 @@
+{
+  "schemaVersion": 1,
+  "files": [
+    ".htaccess", "area-do-usuario.html", "automacao-ia.html", "blog.html", "contactos.html", "crm-gestao.html", "index.html", "landing-page.html", "politica-privacidade.html", "processo.html", "robots.txt", "servicos.html", "sitemap.xml",
+    "src/css/branct.css", "src/css/main.css",
+    "src/fonts/bricolage-grotesque-latin-ext.woff2", "src/fonts/bricolage-grotesque-latin.woff2", "src/fonts/font-faces.css", "src/fonts/manrope-latin-ext.woff2", "src/fonts/manrope-latin.woff2",
+    "src/i18n/en.json", "src/i18n/hr.json", "src/i18n/it.json", "src/i18n/pt.json",
+    "src/img/3.jpg", "src/img/56.jpg", "src/img/albinosantos.jpg", "src/img/apple-touch-icon.png", "src/img/automacao.jpg", "src/img/branding.jpg", "src/img/case-albino.webp", "src/img/case-kb.webp", "src/img/case-neoprag.webp", "src/img/case-vertexway.webp", "src/img/crm-dashboard-860.webp", "src/img/crm-dashboard.jpg", "src/img/crm-dashboard.webp", "src/img/crm-demo-poster.jpg", "src/img/crm-demo-poster.webp", "src/img/crm-demo.mp4", "src/img/crm-demo.webm", "src/img/crm.jpg", "src/img/favicon.ico", "src/img/icon.svg", "src/img/kb.jpg", "src/img/neoprag.jpg", "src/img/notebook.png", "src/img/vertexway.jpg", "src/img/website-940.webp", "src/img/website.jpg",
+    "src/js/branct.js", "src/js/main.js", "src/js/three-scene.js", "src/js/trial.js", "styleguide.html", "website-premium.html"
+  ]
+}

--- a/docs/deploy-protection/scope-matrix.md
+++ b/docs/deploy-protection/scope-matrix.md
@@ -1,0 +1,65 @@
+# Proteção do deploy FTP por escopo
+
+Issue-lock: #3
+
+Base: `main@da8800cd7669f66a82cbf9cd2e4f22fa99d59320`
+
+Branch: `agent/deploy-scope-guard`
+
+## Estado observado
+
+O workflow anterior tinha `push.branches: [main]` sem filtro de caminhos. Portanto, qualquer merge/push na `main` — inclusive somente documentação, testes, fixtures ou workflow de auditoria — iniciava o job que contém FTP.
+
+O `lftp mirror` atual publica, a partir da árvore versionada na base, os HTML raiz, `.htaccess`, `robots.txt`, `sitemap.xml`, CSS, JavaScript, fontes, traduções e media em `src/img/`. O próprio mirror exclui `src/img/video.mp4`, documentação, GitHub workflows, dependências, Supabase, modelos e fontes 3D. Nenhum comando FTP foi executado para obter esta conclusão; ela resulta da leitura integral do workflow e da enumeração da árvore Git.
+
+## Lista positiva automática
+
+- `*.html`
+- `.htaccess`
+- `robots.txt`
+- `sitemap.xml`
+- `src/css/**`
+- `src/js/**`
+- `src/fonts/**`
+- `src/i18n/**`
+- `src/img/**`, mantendo a exclusão já existente de `src/img/video.mp4`
+
+Alterar o próprio workflow não pertence à lista de push e não publica automaticamente. `workflow_dispatch` permite execução manual deliberada somente a partir da `main`. Em pull requests que alterem esta proteção, somente o job offline `verify-scope` pode executar; o job `deploy` rejeita eventos `pull_request` por condição explícita.
+
+## Tabela de verdade executável
+
+| Caso | Deploy automático |
+|---|---|
+| Somente `docs/audit/**` | não |
+| Somente `tests/**` | não |
+| Somente `fixtures/audit/**` | não |
+| HTML raiz | sim |
+| `src/css/**` | sim |
+| `src/js/**` | sim |
+| Imagem/media publicado | sim |
+| Fonte publicada | sim |
+| Tradução `src/i18n/**` | sim |
+| Documentação + ficheiro vivo | sim |
+| Somente workflow de auditoria | não |
+| Somente workflow de deploy | não |
+| `src/img/video.mp4` | não |
+| `workflow_dispatch` autorizado na `main` | permitido |
+
+A matriz vive em `tests/deploy/deploy-scope.test.mjs` e também enumera todos os ficheiros vivos atuais para detetar omissões futuras.
+
+## RED→GREEN
+
+RED: 4/5 testes falharam na base. O caso “somente documentação” devolveu `true`; não existiam `workflow_dispatch`, separação PR/deploy ou Actions pinadas.
+
+GREEN: o filtro positivo, o despacho manual, as condições de jobs e os SHAs imutáveis satisfazem 5/5 testes. O bloco protegido desde o comentário “O repo fica legível” até ao fim mantém SHA-256 `7c4c0839fe38865b61aa4cef463788f163d3e8f8adefdbe59b4e2d4b4e0264ea`, cobrindo minificação, instalação, variáveis, destino e comando mirror.
+
+## Riscos e rollback
+
+- Um novo tipo de caminho vivo exigirá atualização explícita da lista positiva. O teste cobre toda a árvore viva atual, não ficheiros futuros ainda inexistentes.
+- O payload do mirror continua com as exclusões originais por exigência de não alterar comandos. Esta missão controla o gatilho; não redesenha a política de conteúdo do mirror.
+- `workflow_dispatch` é uma capacidade manual sensível, limitada pela condição do job à `main`, e deve ser usada somente por operador autorizado.
+- Rollback: reverter exclusivamente o commit desta missão. Isso restaura o gatilho genérico anterior; portanto, o rollback deve ocorrer apenas com consciência de que merges documentais voltariam a poder iniciar FTP.
+
+## Gate
+
+Nenhum FTP, deploy, secret, produção, página, CSS, JavaScript ou asset vivo foi tocado. Parar antes do merge e aguardar revisão defensiva e autorização humana.

--- a/docs/deploy-protection/scope-matrix.md
+++ b/docs/deploy-protection/scope-matrix.md
@@ -10,7 +10,7 @@ Branch: `agent/deploy-scope-guard`
 
 O workflow anterior tinha `push.branches: [main]` sem filtro de caminhos. Portanto, qualquer merge/push na `main` — inclusive somente documentação, testes, fixtures ou workflow de auditoria — iniciava o job que contém FTP.
 
-O `lftp mirror` atual publica, a partir da árvore versionada na base, os HTML raiz, `.htaccess`, `robots.txt`, `sitemap.xml`, CSS, JavaScript, fontes, traduções e media em `src/img/`. O próprio mirror exclui `src/img/video.mp4`, documentação, GitHub workflows, dependências, Supabase, modelos e fontes 3D. Nenhum comando FTP foi executado para obter esta conclusão; ela resulta da leitura integral do workflow e da enumeração da árvore Git.
+No head bloqueado `94450a00c8a2a73fe587f2cb1de954a8acc75196`, o `lftp mirror` ainda usava a raiz `./`. A reprodução offline mostrou quatro fugas no payload efetivo: `tests/deploy/deploy-scope.test.mjs`, o futuro `tests/audit/site-audit.test.mjs`, o futuro `fixtures/audit/baseline-results.json` e `unknown/private.txt`. Nenhum comando FTP foi executado; o RED foi calculado a partir da árvore Git e das exclusões reais do comando.
 
 ## Lista positiva automática
 
@@ -24,7 +24,7 @@ O `lftp mirror` atual publica, a partir da árvore versionada na base, os HTML r
 - `src/i18n/**`
 - `src/img/**`, mantendo a exclusão já existente de `src/img/video.mp4`
 
-Alterar o próprio workflow não pertence à lista de push e não publica automaticamente. `workflow_dispatch` permite execução manual deliberada somente a partir da `main`. Em pull requests que alterem esta proteção, somente o job offline `verify-scope` pode executar; o job `deploy` rejeita eventos `pull_request` por condição explícita.
+Esta lista em `push.paths` é a definição canónica. Antes de instalar ou invocar `lftp`, `scripts/deploy/build-publish-payload.mjs` lê essa mesma definição, valida-a contra a política fechada e copia somente ficheiros Git autorizados para `${RUNNER_TEMP}/branct-publish`. O mirror usa exclusivamente essa pasta temporária, nunca a raiz do repositório. Alterar o próprio workflow não pertence à lista de push e não publica automaticamente. `workflow_dispatch` permite execução manual deliberada somente a partir da `main`. Em pull requests, somente `verify-scope` executa; o job `deploy` rejeita o evento.
 
 ## Tabela de verdade executável
 
@@ -45,20 +45,22 @@ Alterar o próprio workflow não pertence à lista de push e não publica automa
 | `src/img/video.mp4` | não |
 | `workflow_dispatch` autorizado na `main` | permitido |
 
-A matriz vive em `tests/deploy/deploy-scope.test.mjs` e também enumera todos os ficheiros vivos atuais para detetar omissões futuras.
+A matriz vive em `tests/deploy/deploy-scope.test.mjs`. `expected-payload.json` mantém uma lista explícita e independente dos 56 ficheiros publicados atuais. O teste enumera a árvore produzida e exige igualdade exata, sem reutilizar o classificador como oráculo. Há negativos permanentes para PR #2, testes, fixtures, documentação, workflows, dependências, diretórios desconhecidos, ficheiros obrigatórios ausentes, duplicações, travessia e symlinks.
 
 ## RED→GREEN
 
-RED: 4/5 testes falharam na base. O caso “somente documentação” devolveu `true`; não existiam `workflow_dispatch`, separação PR/deploy ou Actions pinadas.
+RED inicial da missão: 4/5 testes falharam na base. O caso “somente documentação” devolveu `true`; não existiam `workflow_dispatch`, separação PR/deploy ou Actions pinadas.
 
-GREEN: o filtro positivo, o despacho manual, as condições de jobs e os SHAs imutáveis satisfazem 5/5 testes. O bloco protegido desde o comentário “O repo fica legível” até ao fim mantém SHA-256 `7c4c0839fe38865b61aa4cef463788f163d3e8f8adefdbe59b4e2d4b4e0264ea`, cobrindo minificação, instalação, variáveis, destino e comando mirror.
+RED desta correção: 6/7 testes passaram e o negativo do payload falhou com quatro entradas indevidas: teste atual, teste e fixture projetados da PR #2 e diretório desconhecido.
+
+GREEN: 8/8 testes passam. O pacote contém exatamente os 56 ficheiros listados no contrato independente, e zero ficheiros de `tests/`, `fixtures/`, `docs/`, `.github/`, dependências ou diretórios desconhecidos. O destino FTP, nomes dos secrets, opções de sincronização e `--delete` permanecem no workflow; somente a origem do mirror mudou de `./` para o staging fechado.
 
 ## Riscos e rollback
 
-- Um novo tipo de caminho vivo exigirá atualização explícita da lista positiva. O teste cobre toda a árvore viva atual, não ficheiros futuros ainda inexistentes.
-- O payload do mirror continua com as exclusões originais por exigência de não alterar comandos. Esta missão controla o gatilho; não redesenha a política de conteúdo do mirror.
+- Um novo tipo de caminho vivo exigirá atualização deliberada da política canónica, do construtor e do contrato independente. Por desenho, a omissão falha fechada.
+- A lista explícita dos 56 ficheiros é um snapshot da árvore atual. Adicionar ou remover um asset vivo exige atualizar esse contrato no mesmo PR.
 - `workflow_dispatch` é uma capacidade manual sensível, limitada pela condição do job à `main`, e deve ser usada somente por operador autorizado.
-- Rollback: reverter exclusivamente o commit desta missão. Isso restaura o gatilho genérico anterior; portanto, o rollback deve ocorrer apenas com consciência de que merges documentais voltariam a poder iniciar FTP.
+- Rollback: reverter exclusivamente o commit corretivo para o head anterior da PR. Isso reabre o payload da raiz e não deve ser fundido; a alternativa segura é desativar o workflow até corrigir.
 
 ## Gate
 

--- a/docs/deploy-protection/scope-matrix.md
+++ b/docs/deploy-protection/scope-matrix.md
@@ -24,7 +24,9 @@ No head bloqueado `94450a00c8a2a73fe587f2cb1de954a8acc75196`, o `lftp mirror` ai
 - `src/i18n/**`
 - `src/img/**`, mantendo a exclusão já existente de `src/img/video.mp4`
 
-Esta lista em `push.paths` é a definição canónica. Antes de instalar ou invocar `lftp`, `scripts/deploy/build-publish-payload.mjs` lê essa mesma definição, valida-a contra a política fechada e copia somente ficheiros Git autorizados para `${RUNNER_TEMP}/branct-publish`. O mirror usa exclusivamente essa pasta temporária, nunca a raiz do repositório. Alterar o próprio workflow não pertence à lista de push e não publica automaticamente. `workflow_dispatch` permite execução manual deliberada somente a partir da `main`. Em pull requests, somente `verify-scope` executa; o job `deploy` rejeita o evento.
+Esta lista em `push.paths` é a política canónica de tipos. O manifesto operacional `deploy/publish-manifest.json` é a lista exata de instâncias atualmente publicadas. Antes de instalar ou invocar `lftp`, `scripts/deploy/build-publish-payload.mjs` lê e valida as duas camadas, exige igualdade exata entre árvore selecionada e manifesto, e copia somente esse conjunto para `${RUNNER_TEMP}/branct-publish`. Um caminho precisa ser autorizado pela política e constar no manifesto; nenhuma camada amplia a outra. O mirror usa exclusivamente a pasta temporária, nunca a raiz do repositório.
+
+Alterar o próprio workflow ou manifesto não pertence à lista de `push` e não publica automaticamente. `workflow_dispatch` permite execução manual deliberada somente a partir da `main`. Em pull requests, qualquer alteração viva, do workflow, construtor, manifesto, testes ou documentação de deploy inicia somente `verify-scope`; o job `deploy` rejeita o evento.
 
 ## Tabela de verdade executável
 
@@ -45,7 +47,7 @@ Esta lista em `push.paths` é a definição canónica. Antes de instalar ou invo
 | `src/img/video.mp4` | não |
 | `workflow_dispatch` autorizado na `main` | permitido |
 
-A matriz vive em `tests/deploy/deploy-scope.test.mjs`. `expected-payload.json` mantém uma lista explícita e independente dos 56 ficheiros publicados atuais. O teste enumera a árvore produzida e exige igualdade exata, sem reutilizar o classificador como oráculo. Há negativos permanentes para PR #2, testes, fixtures, documentação, workflows, dependências, diretórios desconhecidos, ficheiros obrigatórios ausentes, duplicações, travessia e symlinks.
+A matriz vive em `tests/deploy/deploy-scope.test.mjs`. `deploy/publish-manifest.json` mantém os 56 ficheiros publicados atuais e é consumido pelo construtor real e pelos testes. A suite enumera a árvore produzida e exige igualdade exata com o manifesto. Há negativos permanentes para PR #2, testes, fixtures, documentação, workflows, dependências, diretórios desconhecidos, ficheiro permitido extra, ficheiro manifestado ausente, manifesto proibido/duplicado/ausente/ilegível/schema inválido, travessia e symlinks.
 
 ## RED→GREEN
 
@@ -53,12 +55,16 @@ RED inicial da missão: 4/5 testes falharam na base. O caso “somente documenta
 
 RED desta correção: 6/7 testes passaram e o negativo do payload falhou com quatro entradas indevidas: teste atual, teste e fixture projetados da PR #2 e diretório desconhecido.
 
-GREEN: 8/8 testes passam. O pacote contém exatamente os 56 ficheiros listados no contrato independente, e zero ficheiros de `tests/`, `fixtures/`, `docs/`, `.github/`, dependências ou diretórios desconhecidos. O destino FTP, nomes dos secrets, opções de sincronização e `--delete` permanecem no workflow; somente a origem do mirror mudou de `./` para o staging fechado.
+GREEN do fecho da raiz: 8/8 testes passaram. O pacote continha exatamente os 56 ficheiros então listados no contrato de teste, e zero ficheiros de `tests/`, `fixtures/`, `docs/`, `.github/`, dependências ou diretórios desconhecidos. O destino FTP, nomes dos secrets, opções de sincronização e `--delete` permaneceram no workflow; somente a origem do mirror mudou de `./` para o staging fechado.
+
+RED da vinculação operacional: 8 testes anteriores passaram e 3 novos falharam. O construtor aceitou `novo.html`, aceitou a remoção de `src/css/main.css` e `index.html` não disparava a verificação de PR.
+
+GREEN da vinculação operacional: 13/13 testes passam. O construtor real carrega o manifesto antes do staging e aborta por qualquer diferença extra/ausente ou manifesto inválido. Todos os tipos de caminhos vivos e o manifesto estão no filtro da verificação de pull request.
 
 ## Riscos e rollback
 
 - Um novo tipo de caminho vivo exigirá atualização deliberada da política canónica, do construtor e do contrato independente. Por desenho, a omissão falha fechada.
-- A lista explícita dos 56 ficheiros é um snapshot da árvore atual. Adicionar ou remover um asset vivo exige atualizar esse contrato no mesmo PR.
+- O manifesto operacional de 56 ficheiros é um snapshot da árvore atual. Adicionar ou remover um ficheiro vivo exige atualizar o manifesto no mesmo PR; caso contrário, tanto CI como o construtor real abortam.
 - `workflow_dispatch` é uma capacidade manual sensível, limitada pela condição do job à `main`, e deve ser usada somente por operador autorizado.
 - Rollback: reverter exclusivamente o commit corretivo para o head anterior da PR. Isso reabre o payload da raiz e não deve ser fundido; a alternativa segura é desativar o workflow até corrigir.
 

--- a/scripts/deploy/build-publish-payload.mjs
+++ b/scripts/deploy/build-publish-payload.mjs
@@ -9,10 +9,7 @@ export const EXPECTED_POLICY = Object.freeze([
   "src/img/**", "!src/img/video.mp4",
 ]);
 
-export const REQUIRED_FILES = Object.freeze([
-  ".htaccess", "index.html", "robots.txt", "sitemap.xml",
-  "src/css/branct.css", "src/js/branct.js", "src/js/trial.js",
-]);
+export const MANIFEST_PATH = "deploy/publish-manifest.json";
 
 export function readPushPaths(yaml) {
   const lines = yaml.replace(/\r\n/g, "\n").split("\n");
@@ -50,6 +47,32 @@ function normalizeCandidate(candidate) {
   return normalized;
 }
 
+export async function readPublishManifest(rootReal, rules) {
+  let raw;
+  try {
+    raw = await readFile(path.join(rootReal, MANIFEST_PATH), "utf8");
+  } catch (error) {
+    throw new Error(`publish manifest unreadable: ${error.code ?? error.message}`);
+  }
+  let manifest;
+  try {
+    manifest = JSON.parse(raw);
+  } catch {
+    throw new Error("publish manifest unreadable: invalid JSON");
+  }
+  if (!manifest || typeof manifest !== "object" || Array.isArray(manifest)
+      || manifest.schemaVersion !== 1 || !Array.isArray(manifest.files)
+      || Object.keys(manifest).sort().join(",") !== "files,schemaVersion") {
+    throw new Error("publish manifest schema invalid");
+  }
+  const files = manifest.files.map(normalizeCandidate);
+  const folded = files.map((entry) => entry.toLowerCase());
+  if (new Set(folded).size !== folded.length) throw new Error("publish manifest contains duplicate path");
+  if (JSON.stringify(files) !== JSON.stringify([...files].sort())) throw new Error("publish manifest paths must be sorted");
+  for (const entry of files) if (!isPublished(rules, entry)) throw new Error(`publish manifest path forbidden by policy: ${entry}`);
+  return files;
+}
+
 async function assertRegularInside(rootReal, relative) {
   let cursor = rootReal;
   for (const segment of relative.split("/")) {
@@ -70,6 +93,7 @@ export async function buildPayload({ source, output, candidates }) {
   if (outputAbsolute === rootReal || outputAbsolute.startsWith(`${rootReal}${path.sep}`)) throw new Error("output must be outside repository root");
   const workflow = await readFile(path.join(rootReal, ".github/workflows/deploy.yml"), "utf8");
   const rules = readPushPaths(workflow);
+  const manifest = await readPublishManifest(rootReal, rules);
   const entries = candidates ?? execFileSync("git", ["-C", rootReal, "ls-files", "-z"], { encoding: "utf8" }).split("\0").filter(Boolean);
   const normalized = entries.map(normalizeCandidate);
   const folded = normalized.map((entry) => entry.toLowerCase());
@@ -77,7 +101,11 @@ export async function buildPayload({ source, output, candidates }) {
   const resolvedFiles = new Map();
   for (const entry of normalized) resolvedFiles.set(entry, await assertRegularInside(rootReal, entry));
   const selected = normalized.filter((entry) => isPublished(rules, entry)).sort();
-  for (const required of REQUIRED_FILES) if (!selected.includes(required)) throw new Error(`required publish file missing: ${required}`);
+  const extra = selected.filter((entry) => !manifest.includes(entry));
+  const missing = manifest.filter((entry) => !selected.includes(entry));
+  if (extra.length || missing.length) {
+    throw new Error(`publish manifest mismatch; extra=[${extra.join(",")}]; missing=[${missing.join(",")}]`);
+  }
   await mkdir(outputAbsolute, { recursive: false });
   for (const relative of selected) {
     const sourceFile = resolvedFiles.get(relative);

--- a/scripts/deploy/build-publish-payload.mjs
+++ b/scripts/deploy/build-publish-payload.mjs
@@ -1,0 +1,97 @@
+import { execFileSync } from "node:child_process";
+import { copyFile, lstat, mkdir, readFile, realpath } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const EXPECTED_POLICY = Object.freeze([
+  "*.html", ".htaccess", "robots.txt", "sitemap.xml",
+  "src/css/**", "src/js/**", "src/fonts/**", "src/i18n/**",
+  "src/img/**", "!src/img/video.mp4",
+]);
+
+export const REQUIRED_FILES = Object.freeze([
+  ".htaccess", "index.html", "robots.txt", "sitemap.xml",
+  "src/css/branct.css", "src/js/branct.js", "src/js/trial.js",
+]);
+
+export function readPushPaths(yaml) {
+  const lines = yaml.replace(/\r\n/g, "\n").split("\n");
+  const push = lines.indexOf("  push:");
+  const paths = lines.findIndex((line, index) => index > push && line === "    paths:");
+  if (push < 0 || paths < 0) throw new Error("missing push.paths policy");
+  const values = [];
+  for (let index = paths + 1; index < lines.length; index += 1) {
+    const match = lines[index].match(/^      - ["'](.+)["']$/);
+    if (!match) break;
+    values.push(match[1]);
+  }
+  if (new Set(values).size !== values.length) throw new Error("duplicate canonical path rule");
+  if (JSON.stringify(values) !== JSON.stringify(EXPECTED_POLICY)) throw new Error("canonical publish policy changed without builder approval");
+  return values;
+}
+
+function matches(pattern, candidate) {
+  const escaped = pattern.replace(/[.+^${}()|[\]\\]/g, "\\$&").replaceAll("**", "\0").replaceAll("*", "[^/]*").replaceAll("\0", ".*");
+  return new RegExp(`^${escaped}$`).test(candidate);
+}
+
+export function isPublished(rules, candidate) {
+  return rules.reduce((included, rule) => rule.startsWith("!")
+    ? (matches(rule.slice(1), candidate) ? false : included)
+    : (matches(rule, candidate) ? true : included), false);
+}
+
+function normalizeCandidate(candidate) {
+  if (typeof candidate !== "string" || candidate.includes("\0") || candidate.includes("\\")) throw new Error(`invalid path entry: ${candidate}`);
+  const normalized = path.posix.normalize(candidate);
+  if (!candidate || normalized !== candidate || path.posix.isAbsolute(candidate) || candidate === ".." || candidate.startsWith("../")) {
+    throw new Error(`path escapes repository: ${candidate}`);
+  }
+  return normalized;
+}
+
+async function assertRegularInside(rootReal, relative) {
+  let cursor = rootReal;
+  for (const segment of relative.split("/")) {
+    cursor = path.join(cursor, segment);
+    const info = await lstat(cursor);
+    if (info.isSymbolicLink()) throw new Error(`symlink refused: ${relative}`);
+  }
+  const resolved = await realpath(cursor);
+  if (resolved !== rootReal && !resolved.startsWith(`${rootReal}${path.sep}`)) throw new Error(`path escapes repository: ${relative}`);
+  const info = await lstat(resolved);
+  if (!info.isFile()) throw new Error(`not a regular file: ${relative}`);
+  return resolved;
+}
+
+export async function buildPayload({ source, output, candidates }) {
+  const rootReal = await realpath(source);
+  const outputAbsolute = path.resolve(output);
+  if (outputAbsolute === rootReal || outputAbsolute.startsWith(`${rootReal}${path.sep}`)) throw new Error("output must be outside repository root");
+  const workflow = await readFile(path.join(rootReal, ".github/workflows/deploy.yml"), "utf8");
+  const rules = readPushPaths(workflow);
+  const entries = candidates ?? execFileSync("git", ["-C", rootReal, "ls-files", "-z"], { encoding: "utf8" }).split("\0").filter(Boolean);
+  const normalized = entries.map(normalizeCandidate);
+  const folded = normalized.map((entry) => entry.toLowerCase());
+  if (new Set(folded).size !== folded.length) throw new Error("duplicate path entry");
+  const resolvedFiles = new Map();
+  for (const entry of normalized) resolvedFiles.set(entry, await assertRegularInside(rootReal, entry));
+  const selected = normalized.filter((entry) => isPublished(rules, entry)).sort();
+  for (const required of REQUIRED_FILES) if (!selected.includes(required)) throw new Error(`required publish file missing: ${required}`);
+  await mkdir(outputAbsolute, { recursive: false });
+  for (const relative of selected) {
+    const sourceFile = resolvedFiles.get(relative);
+    const destination = path.join(outputAbsolute, ...relative.split("/"));
+    await mkdir(path.dirname(destination), { recursive: true });
+    await copyFile(sourceFile, destination);
+  }
+  return selected;
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  const sourceIndex = process.argv.indexOf("--source");
+  const outputIndex = process.argv.indexOf("--output");
+  if (sourceIndex < 0 || outputIndex < 0) throw new Error("usage: --source <repo> --output <empty-path>");
+  const payload = await buildPayload({ source: process.argv[sourceIndex + 1], output: process.argv[outputIndex + 1] });
+  process.stdout.write(`${payload.join("\n")}\n`);
+}

--- a/tests/deploy/deploy-scope.test.mjs
+++ b/tests/deploy/deploy-scope.test.mjs
@@ -1,0 +1,87 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { execFileSync } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const workflowUrl = new URL("../../.github/workflows/deploy.yml", import.meta.url);
+const workflow = await readFile(workflowUrl, "utf8");
+
+function pushPaths(yaml) {
+  const lines = yaml.replace(/\r\n/g, "\n").split("\n");
+  const push = lines.findIndex((line) => line === "  push:");
+  if (push < 0) return [];
+  const paths = lines.findIndex((line, index) => index > push && line === "    paths:");
+  if (paths < 0) return null;
+  const values = [];
+  for (let index = paths + 1; index < lines.length; index += 1) {
+    const match = lines[index].match(/^      - ["']?(.+?)["']?$/);
+    if (!match) break;
+    values.push(match[1]);
+  }
+  return values;
+}
+
+function matches(pattern, path) {
+  const escaped = pattern.replace(/[.+^${}()|[\]\\]/g, "\\$&").replaceAll("**", "\0").replaceAll("*", "[^/]*").replaceAll("\0", ".*");
+  return new RegExp(`^${escaped}$`).test(path);
+}
+
+function automaticDeploy(paths) {
+  const filters = pushPaths(workflow);
+  if (filters === null) return true;
+  return paths.some((path) => filters.reduce((included, filter) => filter.startsWith("!") ? (matches(filter.slice(1), path) ? false : included) : (matches(filter, path) ? true : included), false));
+}
+
+const truthTable = [
+  ["somente documentação", ["docs/audit/report.md"], false],
+  ["somente testes", ["tests/audit/site-audit.test.mjs"], false],
+  ["somente evidências", ["fixtures/audit/baseline-results.json"], false],
+  ["HTML", ["index.html"], true],
+  ["CSS", ["src/css/branct.css"], true],
+  ["JavaScript", ["src/js/branct.js"], true],
+  ["imagem", ["src/img/crm-dashboard.webp"], true],
+  ["fonte", ["src/fonts/manrope-latin.woff2"], true],
+  ["i18n", ["src/i18n/pt.json"], true],
+  ["documentação + vivo", ["docs/audit/report.md", "website-premium.html"], true],
+  ["workflow de auditoria", [".github/workflows/audit-offline.yml"], false],
+  ["workflow de deploy", [".github/workflows/deploy.yml"], false],
+  ["asset fonte excluído", ["src/img/video.mp4"], false],
+];
+
+test("push automático segue a tabela de verdade positiva", () => {
+  for (const [name, paths, expected] of truthTable) {
+    assert.equal(automaticDeploy(paths), expected, name);
+  }
+});
+
+test("deploy manual controlado permanece disponível", () => {
+  assert.equal(/^  workflow_dispatch:\s*$/m.test(workflow), true, "workflow_dispatch must exist");
+  assert.equal(/github\.event_name == 'workflow_dispatch' && github\.ref == 'refs\/heads\/main'/.test(workflow), true, "manual deploy must be restricted to main");
+});
+
+test("payload FTP permanece byte-equivalente e Actions ficam pinadas", () => {
+  const marker = "      # O repo";
+  const protectedPayload = workflow.slice(workflow.indexOf(marker)).replace(/\r\n/g, "\n");
+  assert.equal(createHash("sha256").update(protectedPayload).digest("hex"), "7c4c0839fe38865b61aa4cef463788f163d3e8f8adefdbe59b4e2d4b4e0264ea");
+  assert.equal(/uses:\s+actions\/(checkout|setup-node)@v\d/.test(workflow), false, "Actions must use immutable SHAs");
+});
+
+test("workflow separa verificação de PR do job que pode publicar", () => {
+  assert.equal(/^  pull_request:\s*$/m.test(workflow), true, "pull_request verification trigger must exist");
+  assert.equal(/github\.event_name == 'pull_request'/.test(workflow), true, "verification job must be PR-only");
+  assert.equal(/github\.event_name == 'push' \|\| \(github\.event_name == 'workflow_dispatch'/.test(workflow), true, "deploy job must reject pull_request events");
+});
+
+test("lista positiva cobre todos os ficheiros vivos atuais", () => {
+  const tracked = execFileSync("git", ["ls-files"], { encoding: "utf8" }).trim().split(/\r?\n/);
+  const live = tracked.filter((path) => /^(?:[^/]+\.html|\.htaccess|robots\.txt|sitemap\.xml|src\/(?:css|js|fonts|i18n)\/|src\/img\/(?!video\.mp4$))/.test(path));
+  assert.ok(live.length > 20);
+  for (const path of live) assert.equal(automaticDeploy([path]), true, `live path omitted: ${path}`);
+});
+
+test("artefactos offline não contêm expressões de secrets", async () => {
+  const secretExpression = ["$", "{{", " secrets."].join("");
+  const files = [new URL(import.meta.url), new URL("../../docs/deploy-protection/scope-matrix.md", import.meta.url)];
+  for (const file of files) assert.equal((await readFile(file, "utf8")).includes(secretExpression), false);
+});

--- a/tests/deploy/deploy-scope.test.mjs
+++ b/tests/deploy/deploy-scope.test.mjs
@@ -8,7 +8,8 @@ import { buildPayload, EXPECTED_POLICY, readPushPaths } from "../../scripts/depl
 
 const root = path.resolve(new URL("../..", import.meta.url).pathname.replace(/^\/(.:)/, "$1"));
 const workflow = await readFile(path.join(root, ".github/workflows/deploy.yml"), "utf8");
-const expected = JSON.parse(await readFile(new URL("./expected-payload.json", import.meta.url), "utf8"));
+const manifestPath = path.join(root, "deploy/publish-manifest.json");
+const expected = JSON.parse(await readFile(manifestPath, "utf8")).files;
 
 function matches(pattern, candidate) {
   const escaped = pattern.replace(/[.+^${}()|[\]\\]/g, "\\$&").replaceAll("**", "\0").replaceAll("*", "[^/]*").replaceAll("\0", ".*");
@@ -19,6 +20,24 @@ function automaticDeploy(paths) {
   return paths.some((candidate) => EXPECTED_POLICY.reduce((included, rule) => rule.startsWith("!")
     ? (matches(rule.slice(1), candidate) ? false : included)
     : (matches(rule, candidate) ? true : included), false));
+}
+
+function pullRequestPaths(yaml) {
+  const lines = yaml.replace(/\r\n/g, "\n").split("\n");
+  const pullRequest = lines.indexOf("  pull_request:");
+  const paths = lines.findIndex((line, index) => index > pullRequest && line === "    paths:");
+  const values = [];
+  for (let index = paths + 1; index < lines.length; index += 1) {
+    const match = lines[index].match(/^      - ["'](.+)["']$/);
+    if (!match) break;
+    values.push(match[1]);
+  }
+  return values;
+}
+
+function pullRequestVerification(changed) {
+  const rules = pullRequestPaths(workflow);
+  return changed.some((candidate) => rules.some((rule) => matches(rule, candidate)));
 }
 
 async function treeFiles(directory, prefix = "") {
@@ -57,7 +76,7 @@ test("uma definição canónica governa gatilho e construtor", () => {
   assert.doesNotMatch(workflow, /uses:\s+actions\/(?:checkout|setup-node)@v\d/);
 });
 
-test("payload real é exatamente a lista independente esperada", async () => {
+test("staging real é exatamente o manifesto operacional", async () => {
   const temp = await mkdtemp(path.join(os.tmpdir(), "branct-payload-"));
   try {
     const actual = await buildPayload({ source: root, output: temp + "-out" });
@@ -89,7 +108,7 @@ test("PR #2 projetada e caminhos internos ficam fora do payload", async () => {
 test("falha fechada para ausências, duplicações e travessia", async () => {
   const tracked = execFileSync("git", ["ls-files"], { cwd: root, encoding: "utf8" }).trim().split(/\r?\n/);
   await withTempRepo(async ({ source, output }) => {
-    await assert.rejects(buildPayload({ source, output, candidates: tracked.filter((item) => item !== "index.html") }), /required publish file missing/);
+    await assert.rejects(buildPayload({ source, output, candidates: tracked.filter((item) => item !== "index.html") }), /publish manifest mismatch/);
   });
   await withTempRepo(async ({ source, output }) => {
     await assert.rejects(buildPayload({ source, output, candidates: [...tracked, "index.html"] }), /duplicate path entry/);
@@ -122,4 +141,62 @@ test("testes e documentação não contêm expressões de credenciais", async ()
   for (const file of [new URL(import.meta.url), new URL("../../docs/deploy-protection/scope-matrix.md", import.meta.url)]) {
     assert.equal((await readFile(file, "utf8")).includes(expression), false);
   }
+});
+
+test("ficheiro permitido novo exige atualização do manifesto", async () => {
+  const tracked = execFileSync("git", ["ls-files"], { cwd: root, encoding: "utf8" }).trim().split(/\r?\n/);
+  await withTempRepo(async ({ source, output }) => {
+    await writeFile(path.join(source, "novo.html"), "<!doctype html>");
+    await assert.rejects(buildPayload({ source, output, candidates: [...tracked, "novo.html"] }), /manifest/i);
+  });
+});
+
+test("remoção de ficheiro publicado exige atualização do manifesto", async () => {
+  const tracked = execFileSync("git", ["ls-files"], { cwd: root, encoding: "utf8" }).trim().split(/\r?\n/);
+  await withTempRepo(async ({ source, output }) => {
+    await rm(path.join(source, "src/css/main.css"));
+    await assert.rejects(buildPayload({ source, output, candidates: tracked.filter((entry) => entry !== "src/css/main.css") }), /manifest/i);
+  });
+});
+
+test("toda alteração viva isolada dispara verificação da PR", () => {
+  const live = ["index.html", ".htaccess", "robots.txt", "sitemap.xml", "src/css/branct.css", "src/js/branct.js", "src/fonts/manrope-latin.woff2", "src/i18n/pt.json", "src/img/icon.svg", "src/img/video.mp4"];
+  for (const candidate of live) assert.equal(pullRequestVerification([candidate]), true, candidate);
+  assert.equal(pullRequestVerification(["deploy/publish-manifest.json"]), true, "operational manifest");
+});
+
+test("manifesto não pode autorizar caminho proibido nem duplicado", async () => {
+  const tracked = execFileSync("git", ["ls-files"], { cwd: root, encoding: "utf8" }).trim().split(/\r?\n/);
+  await withTempRepo(async ({ source, output }) => {
+    const manifestFile = path.join(source, "deploy/publish-manifest.json");
+    const manifest = JSON.parse(await readFile(manifestFile, "utf8"));
+    manifest.files.push("tests/deploy/deploy-scope.test.mjs");
+    manifest.files.sort();
+    await writeFile(manifestFile, JSON.stringify(manifest));
+    await assert.rejects(buildPayload({ source, output, candidates: tracked }), /forbidden by policy/);
+  });
+  await withTempRepo(async ({ source, output }) => {
+    const manifestFile = path.join(source, "deploy/publish-manifest.json");
+    const manifest = JSON.parse(await readFile(manifestFile, "utf8"));
+    manifest.files.push(manifest.files[0]);
+    manifest.files.sort();
+    await writeFile(manifestFile, JSON.stringify(manifest));
+    await assert.rejects(buildPayload({ source, output, candidates: tracked }), /duplicate path/);
+  });
+});
+
+test("manifesto ausente, ilegível ou com schema incorreto interrompe", async () => {
+  const tracked = execFileSync("git", ["ls-files"], { cwd: root, encoding: "utf8" }).trim().split(/\r?\n/);
+  await withTempRepo(async ({ source, output }) => {
+    await rm(path.join(source, "deploy/publish-manifest.json"));
+    await assert.rejects(buildPayload({ source, output, candidates: tracked }), /manifest unreadable/);
+  });
+  await withTempRepo(async ({ source, output }) => {
+    await writeFile(path.join(source, "deploy/publish-manifest.json"), "not-json");
+    await assert.rejects(buildPayload({ source, output, candidates: tracked }), /manifest unreadable/);
+  });
+  await withTempRepo(async ({ source, output }) => {
+    await writeFile(path.join(source, "deploy/publish-manifest.json"), JSON.stringify({ schemaVersion: 2, files: [] }));
+    await assert.rejects(buildPayload({ source, output, candidates: tracked }), /schema invalid/);
+  });
 });

--- a/tests/deploy/deploy-scope.test.mjs
+++ b/tests/deploy/deploy-scope.test.mjs
@@ -1,87 +1,125 @@
 import assert from "node:assert/strict";
-import { createHash } from "node:crypto";
 import { execFileSync } from "node:child_process";
-import { readFile } from "node:fs/promises";
+import { cp, lstat, mkdtemp, readFile, readdir, rm, symlink, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import test from "node:test";
+import { buildPayload, EXPECTED_POLICY, readPushPaths } from "../../scripts/deploy/build-publish-payload.mjs";
 
-const workflowUrl = new URL("../../.github/workflows/deploy.yml", import.meta.url);
-const workflow = await readFile(workflowUrl, "utf8");
+const root = path.resolve(new URL("../..", import.meta.url).pathname.replace(/^\/(.:)/, "$1"));
+const workflow = await readFile(path.join(root, ".github/workflows/deploy.yml"), "utf8");
+const expected = JSON.parse(await readFile(new URL("./expected-payload.json", import.meta.url), "utf8"));
 
-function pushPaths(yaml) {
-  const lines = yaml.replace(/\r\n/g, "\n").split("\n");
-  const push = lines.findIndex((line) => line === "  push:");
-  if (push < 0) return [];
-  const paths = lines.findIndex((line, index) => index > push && line === "    paths:");
-  if (paths < 0) return null;
-  const values = [];
-  for (let index = paths + 1; index < lines.length; index += 1) {
-    const match = lines[index].match(/^      - ["']?(.+?)["']?$/);
-    if (!match) break;
-    values.push(match[1]);
-  }
-  return values;
-}
-
-function matches(pattern, path) {
+function matches(pattern, candidate) {
   const escaped = pattern.replace(/[.+^${}()|[\]\\]/g, "\\$&").replaceAll("**", "\0").replaceAll("*", "[^/]*").replaceAll("\0", ".*");
-  return new RegExp(`^${escaped}$`).test(path);
+  return new RegExp(`^${escaped}$`).test(candidate);
 }
 
 function automaticDeploy(paths) {
-  const filters = pushPaths(workflow);
-  if (filters === null) return true;
-  return paths.some((path) => filters.reduce((included, filter) => filter.startsWith("!") ? (matches(filter.slice(1), path) ? false : included) : (matches(filter, path) ? true : included), false));
+  return paths.some((candidate) => EXPECTED_POLICY.reduce((included, rule) => rule.startsWith("!")
+    ? (matches(rule.slice(1), candidate) ? false : included)
+    : (matches(rule, candidate) ? true : included), false));
 }
 
-const truthTable = [
-  ["somente documentação", ["docs/audit/report.md"], false],
-  ["somente testes", ["tests/audit/site-audit.test.mjs"], false],
-  ["somente evidências", ["fixtures/audit/baseline-results.json"], false],
-  ["HTML", ["index.html"], true],
-  ["CSS", ["src/css/branct.css"], true],
-  ["JavaScript", ["src/js/branct.js"], true],
-  ["imagem", ["src/img/crm-dashboard.webp"], true],
-  ["fonte", ["src/fonts/manrope-latin.woff2"], true],
-  ["i18n", ["src/i18n/pt.json"], true],
-  ["documentação + vivo", ["docs/audit/report.md", "website-premium.html"], true],
-  ["workflow de auditoria", [".github/workflows/audit-offline.yml"], false],
-  ["workflow de deploy", [".github/workflows/deploy.yml"], false],
-  ["asset fonte excluído", ["src/img/video.mp4"], false],
-];
+async function treeFiles(directory, prefix = "") {
+  const result = [];
+  for (const entry of await readdir(directory, { withFileTypes: true })) {
+    const relative = prefix ? `${prefix}/${entry.name}` : entry.name;
+    if (entry.isDirectory()) result.push(...await treeFiles(path.join(directory, entry.name), relative));
+    else result.push(relative);
+  }
+  return result.sort();
+}
 
-test("push automático segue a tabela de verdade positiva", () => {
-  for (const [name, paths, expected] of truthTable) {
-    assert.equal(automaticDeploy(paths), expected, name);
+async function withTempRepo(action) {
+  const temp = await mkdtemp(path.join(os.tmpdir(), "branct-deploy-test-"));
+  const source = path.join(temp, "repo");
+  const output = path.join(temp, "payload");
+  await cp(root, source, { recursive: true, filter: (item) => path.basename(item) !== ".git" });
+  try { await action({ source, output }); } finally { await rm(temp, { recursive: true, force: true }); }
+}
+
+test("gatilho automático segue a tabela de verdade", () => {
+  const cases = [
+    [["docs/audit/report.md"], false], [["tests/audit/test.mjs"], false], [["fixtures/audit/a.json"], false],
+    [["index.html"], true], [["src/css/branct.css"], true], [["src/js/branct.js"], true],
+    [["src/img/icon.svg"], true], [["src/fonts/manrope-latin.woff2"], true], [["unknown/file.bin"], false],
+    [["docs/audit/report.md", "website-premium.html"], true], [[".github/workflows/audit-offline.yml"], false],
+    [[".github/workflows/deploy.yml"], false], [["src/img/video.mp4"], false],
+  ];
+  for (const [paths, result] of cases) assert.equal(automaticDeploy(paths), result, paths.join(", "));
+});
+
+test("uma definição canónica governa gatilho e construtor", () => {
+  assert.deepEqual(readPushPaths(workflow), EXPECTED_POLICY);
+  assert.match(workflow, /workflow_dispatch:/);
+  assert.match(workflow, /github\.event_name == 'workflow_dispatch' && github\.ref == 'refs\/heads\/main'/);
+  assert.doesNotMatch(workflow, /uses:\s+actions\/(?:checkout|setup-node)@v\d/);
+});
+
+test("payload real é exatamente a lista independente esperada", async () => {
+  const temp = await mkdtemp(path.join(os.tmpdir(), "branct-payload-"));
+  try {
+    const actual = await buildPayload({ source: root, output: temp + "-out" });
+    assert.deepEqual(actual, expected);
+    assert.deepEqual(await treeFiles(temp + "-out"), expected);
+    assert.equal((await lstat(temp + "-out")).isDirectory(), true);
+  } finally {
+    await rm(temp, { recursive: true, force: true });
+    await rm(temp + "-out", { recursive: true, force: true });
   }
 });
 
-test("deploy manual controlado permanece disponível", () => {
-  assert.equal(/^  workflow_dispatch:\s*$/m.test(workflow), true, "workflow_dispatch must exist");
-  assert.equal(/github\.event_name == 'workflow_dispatch' && github\.ref == 'refs\/heads\/main'/.test(workflow), true, "manual deploy must be restricted to main");
+test("PR #2 projetada e caminhos internos ficam fora do payload", async () => {
+  const tracked = execFileSync("git", ["ls-files"], { cwd: root, encoding: "utf8" }).trim().split(/\r?\n/);
+  const additions = ["tests/audit/site-audit.test.mjs", "fixtures/audit/baseline-results.json", "fixtures/audit/invalid-home-390x844.jpg", "docs/audit/report.md", ".github/workflows/audit-offline.yml", "node_modules/pkg/index.js", "unknown/private.txt"];
+  await withTempRepo(async ({ source, output }) => {
+    for (const relative of additions) {
+      const target = path.join(source, relative);
+      await writeFile(target, "offline", { recursive: false }).catch(async () => {
+        await import("node:fs/promises").then(({ mkdir }) => mkdir(path.dirname(target), { recursive: true }));
+        await writeFile(target, "offline");
+      });
+    }
+    const actual = await buildPayload({ source, output, candidates: [...tracked, ...additions] });
+    assert.deepEqual(actual, expected);
+  });
 });
 
-test("payload FTP permanece byte-equivalente e Actions ficam pinadas", () => {
-  const marker = "      # O repo";
-  const protectedPayload = workflow.slice(workflow.indexOf(marker)).replace(/\r\n/g, "\n");
-  assert.equal(createHash("sha256").update(protectedPayload).digest("hex"), "7c4c0839fe38865b61aa4cef463788f163d3e8f8adefdbe59b4e2d4b4e0264ea");
-  assert.equal(/uses:\s+actions\/(checkout|setup-node)@v\d/.test(workflow), false, "Actions must use immutable SHAs");
+test("falha fechada para ausências, duplicações e travessia", async () => {
+  const tracked = execFileSync("git", ["ls-files"], { cwd: root, encoding: "utf8" }).trim().split(/\r?\n/);
+  await withTempRepo(async ({ source, output }) => {
+    await assert.rejects(buildPayload({ source, output, candidates: tracked.filter((item) => item !== "index.html") }), /required publish file missing/);
+  });
+  await withTempRepo(async ({ source, output }) => {
+    await assert.rejects(buildPayload({ source, output, candidates: [...tracked, "index.html"] }), /duplicate path entry/);
+  });
+  await withTempRepo(async ({ source, output }) => {
+    await assert.rejects(buildPayload({ source, output, candidates: [...tracked, "../escape.html"] }), /escapes repository/);
+  });
 });
 
-test("workflow separa verificação de PR do job que pode publicar", () => {
-  assert.equal(/^  pull_request:\s*$/m.test(workflow), true, "pull_request verification trigger must exist");
-  assert.equal(/github\.event_name == 'pull_request'/.test(workflow), true, "verification job must be PR-only");
-  assert.equal(/github\.event_name == 'push' \|\| \(github\.event_name == 'workflow_dispatch'/.test(workflow), true, "deploy job must reject pull_request events");
+test("falha fechada para qualquer symlink rastreado", async () => {
+  if (process.platform === "win32") return;
+  const tracked = execFileSync("git", ["ls-files"], { cwd: root, encoding: "utf8" }).trim().split(/\r?\n/);
+  await withTempRepo(async ({ source, output }) => {
+    const link = path.join(source, "unknown-link.txt");
+    await symlink(path.join(source, "robots.txt"), link);
+    await assert.rejects(buildPayload({ source, output, candidates: [...tracked, "unknown-link.txt"] }), /symlink refused/);
+  });
 });
 
-test("lista positiva cobre todos os ficheiros vivos atuais", () => {
-  const tracked = execFileSync("git", ["ls-files"], { encoding: "utf8" }).trim().split(/\r?\n/);
-  const live = tracked.filter((path) => /^(?:[^/]+\.html|\.htaccess|robots\.txt|sitemap\.xml|src\/(?:css|js|fonts|i18n)\/|src\/img\/(?!video\.mp4$))/.test(path));
-  assert.ok(live.length > 20);
-  for (const path of live) assert.equal(automaticDeploy([path]), true, `live path omitted: ${path}`);
+test("mirror usa apenas staging e preserva sincronização", () => {
+  assert.match(workflow, /mirror --reverse --delete --verbose --parallel=5/);
+  assert.match(workflow, /"\$\{RUNNER_TEMP\}\/branct-publish\/" \/domains\/branct\.com\/public_html\//);
+  assert.doesNotMatch(workflow, /\s\.\/ \/domains\/branct\.com\/public_html\//);
+  assert.match(workflow, /github\.event_name == 'pull_request'/);
+  assert.match(workflow, /github\.event_name == 'push' \|\|/);
 });
 
-test("artefactos offline não contêm expressões de secrets", async () => {
-  const secretExpression = ["$", "{{", " secrets."].join("");
-  const files = [new URL(import.meta.url), new URL("../../docs/deploy-protection/scope-matrix.md", import.meta.url)];
-  for (const file of files) assert.equal((await readFile(file, "utf8")).includes(secretExpression), false);
+test("testes e documentação não contêm expressões de credenciais", async () => {
+  const expression = ["$", "{{", " secrets."].join("");
+  for (const file of [new URL(import.meta.url), new URL("../../docs/deploy-protection/scope-matrix.md", import.meta.url)]) {
+    assert.equal((await readFile(file, "utf8")).includes(expression), false);
+  }
 });

--- a/tests/deploy/expected-payload.json
+++ b/tests/deploy/expected-payload.json
@@ -1,0 +1,8 @@
+[
+  ".htaccess", "area-do-usuario.html", "automacao-ia.html", "blog.html", "contactos.html", "crm-gestao.html", "index.html", "landing-page.html", "politica-privacidade.html", "processo.html", "robots.txt", "servicos.html", "sitemap.xml",
+  "src/css/branct.css", "src/css/main.css",
+  "src/fonts/bricolage-grotesque-latin-ext.woff2", "src/fonts/bricolage-grotesque-latin.woff2", "src/fonts/font-faces.css", "src/fonts/manrope-latin-ext.woff2", "src/fonts/manrope-latin.woff2",
+  "src/i18n/en.json", "src/i18n/hr.json", "src/i18n/it.json", "src/i18n/pt.json",
+  "src/img/3.jpg", "src/img/56.jpg", "src/img/albinosantos.jpg", "src/img/apple-touch-icon.png", "src/img/automacao.jpg", "src/img/branding.jpg", "src/img/case-albino.webp", "src/img/case-kb.webp", "src/img/case-neoprag.webp", "src/img/case-vertexway.webp", "src/img/crm-dashboard-860.webp", "src/img/crm-dashboard.jpg", "src/img/crm-dashboard.webp", "src/img/crm-demo-poster.jpg", "src/img/crm-demo-poster.webp", "src/img/crm-demo.mp4", "src/img/crm-demo.webm", "src/img/crm.jpg", "src/img/favicon.ico", "src/img/icon.svg", "src/img/kb.jpg", "src/img/neoprag.jpg", "src/img/notebook.png", "src/img/vertexway.jpg", "src/img/website-940.webp", "src/img/website.jpg",
+  "src/js/branct.js", "src/js/main.js", "src/js/three-scene.js", "src/js/trial.js", "styleguide.html", "website-premium.html"
+]

--- a/tests/deploy/expected-payload.json
+++ b/tests/deploy/expected-payload.json
@@ -1,8 +1,0 @@
-[
-  ".htaccess", "area-do-usuario.html", "automacao-ia.html", "blog.html", "contactos.html", "crm-gestao.html", "index.html", "landing-page.html", "politica-privacidade.html", "processo.html", "robots.txt", "servicos.html", "sitemap.xml",
-  "src/css/branct.css", "src/css/main.css",
-  "src/fonts/bricolage-grotesque-latin-ext.woff2", "src/fonts/bricolage-grotesque-latin.woff2", "src/fonts/font-faces.css", "src/fonts/manrope-latin-ext.woff2", "src/fonts/manrope-latin.woff2",
-  "src/i18n/en.json", "src/i18n/hr.json", "src/i18n/it.json", "src/i18n/pt.json",
-  "src/img/3.jpg", "src/img/56.jpg", "src/img/albinosantos.jpg", "src/img/apple-touch-icon.png", "src/img/automacao.jpg", "src/img/branding.jpg", "src/img/case-albino.webp", "src/img/case-kb.webp", "src/img/case-neoprag.webp", "src/img/case-vertexway.webp", "src/img/crm-dashboard-860.webp", "src/img/crm-dashboard.jpg", "src/img/crm-dashboard.webp", "src/img/crm-demo-poster.jpg", "src/img/crm-demo-poster.webp", "src/img/crm-demo.mp4", "src/img/crm-demo.webm", "src/img/crm.jpg", "src/img/favicon.ico", "src/img/icon.svg", "src/img/kb.jpg", "src/img/neoprag.jpg", "src/img/notebook.png", "src/img/vertexway.jpg", "src/img/website-940.webp", "src/img/website.jpg",
-  "src/js/branct.js", "src/js/main.js", "src/js/three-scene.js", "src/js/trial.js", "styleguide.html", "website-premium.html"
-]


### PR DESCRIPTION
## Missão separada — proteção do deploy por escopo e payload exato

Relacionada com a Issue-lock #3. Esta PR protege o deploy FTP sem alterar páginas vivas e sem depender do conteúdo da PR #2.

## Base, head e estado aprovado

- Base: `main@da8800cd7669f66a82cbf9cd2e4f22fa99d59320`
- Head aprovado: `949524e131c45478d3c531ec103d74fae73b1537`
- Branch: `agent/deploy-scope-guard`
- Estado: draft, `MERGEABLE/CLEAN`
- Parecer superior: **APPROVED**, exclusivamente para este head — [revisão final](https://github.com/branctstudio-rgb/sitebranct/pull/4#issuecomment-5334079745)

## Escopo exato — cinco ficheiros

1. `.github/workflows/deploy.yml`
2. `deploy/publish-manifest.json`
3. `docs/deploy-protection/scope-matrix.md`
4. `scripts/deploy/build-publish-payload.mjs`
5. `tests/deploy/deploy-scope.test.mjs`

Nenhum HTML, CSS, JavaScript, asset vivo, produção, credencial, PR #2 ou `redesign-light-2026` foi alterado.

## Proteção implementada

- A política canónica define os tipos de caminhos que podem iniciar e integrar uma publicação.
- O manifesto operacional `deploy/publish-manifest.json` define os 56 ficheiros concretos atualmente autorizados.
- O construtor real executado antes do FTP carrega obrigatoriamente política e manifesto.
- O conjunto Git selecionado precisa coincidir com o manifesto nos dois sentidos antes de criar o staging.
- Extra, ausência, duplicação, manifesto ausente/ilegível/schema inválido, caminho proibido, travessia, symlink ou entrada fora da raiz interrompem o job.
- O mirror usa exclusivamente `${RUNNER_TEMP}/branct-publish/`, nunca a raiz do repositório.
- `src/img/video.mp4` é verificado em pull requests, mas permanece excluído do payload.
- Destino FTP, nomes dos secrets, sincronização e `--delete` permanecem inalterados.
- `workflow_dispatch` continua limitado à `main`; pull requests executam somente verificação offline.

## RED → GREEN

RED reproduzido no head anterior:

1. `novo.html` era aceito sem atualização do manifesto.
2. A remoção de `src/css/main.css` era aceita sem atualização do manifesto.
3. Uma alteração isolada em caminho vivo não iniciaria `verify-scope`.

GREEN final:

- 13/13 testes offline passaram.
- Staging físico coincide exatamente com o manifesto operacional.
- Todos os caminhos vivos e todas as superfícies do gate acionam a verificação da PR.
- YAML analisado e `git diff --check` limpo.

## Payload autorizado — 56 ficheiros

O conteúdo normativo completo está em `deploy/publish-manifest.json`:

```text
.htaccess
area-do-usuario.html
automacao-ia.html
blog.html
contactos.html
crm-gestao.html
index.html
landing-page.html
politica-privacidade.html
processo.html
robots.txt
servicos.html
sitemap.xml
src/css/branct.css
src/css/main.css
src/fonts/bricolage-grotesque-latin-ext.woff2
src/fonts/bricolage-grotesque-latin.woff2
src/fonts/font-faces.css
src/fonts/manrope-latin-ext.woff2
src/fonts/manrope-latin.woff2
src/i18n/en.json
src/i18n/hr.json
src/i18n/it.json
src/i18n/pt.json
src/img/3.jpg
src/img/56.jpg
src/img/albinosantos.jpg
src/img/apple-touch-icon.png
src/img/automacao.jpg
src/img/branding.jpg
src/img/case-albino.webp
src/img/case-kb.webp
src/img/case-neoprag.webp
src/img/case-vertexway.webp
src/img/crm-dashboard-860.webp
src/img/crm-dashboard.jpg
src/img/crm-dashboard.webp
src/img/crm-demo-poster.jpg
src/img/crm-demo-poster.webp
src/img/crm-demo.mp4
src/img/crm-demo.webm
src/img/crm.jpg
src/img/favicon.ico
src/img/icon.svg
src/img/kb.jpg
src/img/neoprag.jpg
src/img/notebook.png
src/img/vertexway.jpg
src/img/website-940.webp
src/img/website.jpg
src/js/branct.js
src/js/main.js
src/js/three-scene.js
src/js/trial.js
styleguide.html
website-premium.html
```

## Evidência remota

- CI: [run 32183899030](https://github.com/branctstudio-rgb/sitebranct/actions/runs/32183899030)
- Head do run: `949524e131c45478d3c531ec103d74fae73b1537`
- `Verificar escopo do deploy`: **SUCCESS**
- `Deploy via FTP`: **SKIPPED**, zero passos e nenhum acesso a secrets
- Parecer superior: **APPROVED** no mesmo head

## Riscos e rollback

- Qualquer adição ou remoção no conjunto vivo exige atualização deliberada do manifesto no mesmo PR. A divergência falha fechada.
- Novos tipos de caminhos publicados exigem atualização explícita da política e do manifesto.
- Rollback após merge normal: reverter o merge commit completo. Como isso restauraria o deploy inseguro anterior, manter o workflow desativado até a proteção ser reaplicada e reverificada.

## Gate humano

Esta PR permanece draft. O parecer técnico não autoriza merge, deploy nem produção. O merge normal exige decisão humana explícita vinculada ao head e à base acima. Não usar squash, rebase ou force-push.
