### PR TITLE
Corrigir fixture projetada do teste de deploy

### DIFF
--- a/tests/deploy/deploy-scope.test.mjs
+++ b/tests/deploy/deploy-scope.test.mjs
@@ -92,6 +92,7 @@ test("staging real é exatamente o manifesto operacional", async () => {
 test("PR #2 projetada e caminhos internos ficam fora do payload", async () => {
   const tracked = execFileSync("git", ["ls-files"], { cwd: root, encoding: "utf8" }).trim().split(/\r?\n/);
   const additions = ["tests/audit/site-audit.test.mjs", "fixtures/audit/baseline-results.json", "fixtures/audit/invalid-home-390x844.jpg", "docs/audit/report.md", ".github/workflows/audit-offline.yml", "node_modules/pkg/index.js", "unknown/private.txt"];
+  const projected = [...new Set([...tracked, ...additions])];
   await withTempRepo(async ({ source, output }) => {
     for (const relative of additions) {
       const target = path.join(source, relative);
@@ -100,8 +101,11 @@ test("PR #2 projetada e caminhos internos ficam fora do payload", async () => {
         await writeFile(target, "offline");
       });
     }
-    const actual = await buildPayload({ source, output, candidates: [...tracked, ...additions] });
+    const actual = await buildPayload({ source, output, candidates: projected });
     assert.deepEqual(actual, expected);
+    for (const prefix of ["tests/", "fixtures/", "docs/", ".github/", "node_modules/", "unknown/"]) {
+      assert.equal(actual.some((entry) => entry.startsWith(prefix)), false, `${prefix} must stay outside the payload`);
+    }
   });
 });
 


### PR DESCRIPTION
## Correção test-only — fixture projetada da PR #2

Fecha a causa registrada na Issue #5. Esta PR não altera produção, workflow, manifesto, construtor ou payload.

## Base e head

- Base: `main@7c6c11914d7d9ff24d4a92136761dc57e3b9cde3`
- Head: `5ca89700f0661cf9b2648797270efa17446534a4`
- Branch: `agent/deploy-test-fixture-dedupe`

## RED e causa

Na árvore reconciliada da PR #2 (`ab9801c8dae2ded5cbf118a934f551b57de6967b`), a suite devolvia 12/13. A fixture concatenava 741 caminhos rastreados com sete caminhos sintéticos; quatro já existiam em `git ls-files`:

- `tests/audit/site-audit.test.mjs`
- `fixtures/audit/baseline-results.json`
- `fixtures/audit/invalid-home-390x844.jpg`
- `.github/workflows/audit-offline.yml`

O erro `duplicate path entry` era artificial e ocorria antes da asserção de payload. Com união única, o construtor produz os mesmos 56 ficheiros e zero caminhos internos.

## GREEN

- A fixture combina caminhos reais e sintéticos com `Set`.
- Asserções explícitas mantêm fora do payload: `tests/`, `fixtures/`, `docs/`, `.github/`, `node_modules/` e `unknown/`.
- Main corrigida: 13/13.
- Árvore reconciliada com os 29 ficheiros reais da PR #2: 13/13.
- Negativo independente de duplicação real: PASS; a regra do construtor continua rejeitando `[...tracked, "index.html"]`.
- Contrato da auditoria: 4/4.
- Matriz DOM: 12 rotas × 5 viewports reproduzida, 60/60.
- Evidência visual: 13 ACCEPT; controlo negativo REJECT.
- YAMLs de deploy e auditoria analisados; `git diff --check` limpo.

## Diff exato e invariantes

Único ficheiro alterado: `tests/deploy/deploy-scope.test.mjs` — cinco adições e uma substituição.

Permanecem byte-inalterados:

- `.github/workflows/deploy.yml`
- `deploy/publish-manifest.json`
- `scripts/deploy/build-publish-payload.mjs`
- os 56 caminhos publicados, destino FTP, secrets, staging e `--delete`
- PR #2 e merge local `ab9801c8dae2ded5cbf118a934f551b57de6967b`
- `redesign-light-2026` e produção

## Risco e rollback

Risco: deduplicação da fixture ocultar duplicações reais. Mitigação permanente: teste negativo independente continua exigindo rejeição de entrada duplicada pelo construtor.

Rollback: reverter exclusivamente o commit `5ca89700f0661cf9b2648797270efa17446534a4`.

## Gate

### Evidência remota final

- CI: [run 32219129745](https://github.com/branctstudio-rgb/sitebranct/actions/runs/32219129745)
- Head do run: `5ca89700f0661cf9b2648797270efa17446534a4`
- Evento: `pull_request`
- Verificação offline: **SUCCESS**
- FTP: **SKIPPED**, zero passos
- Deployments no head: **0**
- Revisão defensiva final: **APPROVED**, sem Critical/Important/Minor

PR obrigatoriamente draft. Requer aprovação humana. Não fazer merge, não executar workflow manual, FTP ou deploy.
