### PR TITLE
F2-GOV-03-F1: align personal-account protection payload

### DIFF
--- a/docs/audit/phase-2/governance/f2-gov-03-handoff.md
+++ b/docs/audit/phase-2/governance/f2-gov-03-handoff.md
@@ -12,6 +12,8 @@ Veredicto do pacote: **PROPOSTA_APTA_PARA_DECISAO**, sujeito a CI e revisão def
 - RED inicial: a base não continha o contrato F2-GOV-03. GREEN inicial: 33/33.
 - Revisão defensiva inicial: `CHANGES_REQUIRED` por allowances de bypass não validadas, critérios/rollback autocertificados e cerimónia sem contexto externo.
 - Correção: payload sem allowances, flags anti-bypass, opções/critérios/rollback exatos e cerimónia vinculada a decisão `APPROVED`, ator, identificador, head e base externos.
+- F2-GOV-03-F1 RED: o contrato anterior aceitou e produziu `contexts + checks`, `dismissal_restrictions: {}` e `bypass_pull_request_allowances: {}`; o endpoint real respondeu HTTP 422 nas duas formas tentadas na Issue #40.
+- F2-GOV-03-F1 GREEN: esquema de conta pessoal com apenas `strict + checks`, campos organizacionais omitidos, `restrictions: null`, versão `2022-11-28` explícita e negativos permanentes contra qualquer coleção/bypass incompatível.
 
 ## Decisão pendente
 
@@ -19,6 +21,6 @@ O Conselho ainda decide uma ou duas aprovações, identidades dos aprovadores, i
 
 ## Limites e risco residual
 
-Via B continua obrigatória. A proposta não foi ensaiada como regra ativa, o bypass de ator restrito está `NOT_VERIFIED` e uma indisponibilidade do Actions pode congelar merges. A aplicação futura exige branch descartável, observação na `main`, snapshot/rollback e aprovação humana separada. Zero FTP, deploy, secrets ou produção são autorizados.
+Via B continua obrigatória. A proposta corrigida não foi aplicada: o ensaio anterior parou antes de criar proteção. O bypass de ator restrito está `NOT_VERIFIED` e uma indisponibilidade do Actions pode congelar merges. A aplicação futura exige novo ensaio descartável autorizado, observação na `main`, snapshot/rollback e aprovação humana separada. Zero FTP, deploy, secrets ou produção são autorizados.
 
 Rollback futuro: restaurar o payload anterior sob congelamento de merges e repetir os ensaios. Rollback desta PR documental: `git revert -m 1 <merge_sha>` após eventual merge autorizado, preservando história.

--- a/docs/audit/phase-2/governance/f2-gov-03-proposal.md
+++ b/docs/audit/phase-2/governance/f2-gov-03-proposal.md
@@ -8,6 +8,8 @@ A medição está vinculada a `main@3fd31e615a8914aaa1b1d7bcb0a093222eb678ce`. N
 
 A proposta usa proteção clássica de branch porque o endpoint correspondente foi medido e o payload pode vincular cada check ao GitHub Actions pelo `app_id`. A aplicação futura deve seguir a documentação oficial da [Branch protection API](https://docs.github.com/en/rest/branches/branch-protection) e as [regras de branches protegidas](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches), sempre numa missão separada.
 
+A compatibilidade do pedido foi corrigida offline após os dois HTTP 422 da Issue #40, medidos em `main@32e63a416793a2ba0ca917d71ec652cc6bc22deb`. Para o repositório pertencente a uma conta pessoal, o pedido usa a API `2022-11-28`, envia `required_status_checks` somente com `strict` e `checks`, e omite `dismissal_restrictions` e `bypass_pull_request_allowances`. A omissão não concede bypass: significa que nenhuma coleção de utilizadores, equipas ou aplicações é enviada. `restrictions: null` permanece como campo de topo exigido pelo endpoint.
+
 ## Decisão recomendada, ainda pendente
 
 - Exigir PR e os checks exatos `Gate Integrity Sentinel` e `Universal PR Gate`, ambos provenientes de `github-actions` (`app_id: 15368`) e concluídos com sucesso no head mais recente.
@@ -82,10 +84,21 @@ O bloco seguinte é uma projeção estrutural do manifesto operacional. O teste 
       "finalMethodsRequireCouncilDecision": true,
       "preserveBranch": true
     },
+    "apiCompatibility": {
+      "ownerType": "User",
+      "apiVersion": "2022-11-28",
+      "measuredAtBase": "32e63a416793a2ba0ca917d71ec652cc6bc22deb",
+      "evidenceIssue": 40,
+      "incompatibleRequestFields": [
+        "required_status_checks.contexts with app-bound checks",
+        "required_pull_request_reviews.dismissal_restrictions",
+        "required_pull_request_reviews.bypass_pull_request_allowances"
+      ],
+      "omissionSemantics": "No user, team, app or bypass allowance is granted; omitted organization-only fields are absent permissions."
+    },
     "apiPayload": {
       "required_status_checks": {
         "strict": true,
-        "contexts": [],
         "checks": [
           {
             "context": "Gate Integrity Sentinel",
@@ -99,12 +112,10 @@ O bloco seguinte é uma projeção estrutural do manifesto operacional. O teste 
       },
       "enforce_admins": true,
       "required_pull_request_reviews": {
-        "dismissal_restrictions": {},
         "dismiss_stale_reviews": true,
         "require_code_owner_reviews": false,
         "required_approving_review_count": 1,
-        "require_last_push_approval": true,
-        "bypass_pull_request_allowances": {}
+        "require_last_push_approval": true
       },
       "restrictions": null,
       "required_conversation_resolution": true,
@@ -145,4 +156,4 @@ O bloco seguinte é uma projeção estrutural do manifesto operacional. O teste 
 
 ## Limite vinculativo
 
-O payload acima é candidato, não instrução de execução. Qualquer mudança da base, dos checks, da fonte do app, das decisões humanas ou da capacidade da conta invalida a evidência e exige nova medição, novo CI e nova aprovação.
+O payload acima é candidato, não instrução de execução. Qualquer mudança da base, do tipo de proprietário, da versão da API, dos checks, da fonte do app, das decisões humanas ou da capacidade da conta invalida a evidência e exige nova medição, novo CI e nova aprovação. O próximo passo possível é um novo ensaio descartável com autorização própria; esta correção não o executa.

--- a/fixtures/audit/f2-gov-03-protection-proposal.json
+++ b/fixtures/audit/f2-gov-03-protection-proposal.json
@@ -57,10 +57,21 @@
       "finalMethodsRequireCouncilDecision": true,
       "preserveBranch": true
     },
+    "apiCompatibility": {
+      "ownerType": "User",
+      "apiVersion": "2022-11-28",
+      "measuredAtBase": "32e63a416793a2ba0ca917d71ec652cc6bc22deb",
+      "evidenceIssue": 40,
+      "incompatibleRequestFields": [
+        "required_status_checks.contexts with app-bound checks",
+        "required_pull_request_reviews.dismissal_restrictions",
+        "required_pull_request_reviews.bypass_pull_request_allowances"
+      ],
+      "omissionSemantics": "No user, team, app or bypass allowance is granted; omitted organization-only fields are absent permissions."
+    },
     "apiPayload": {
       "required_status_checks": {
         "strict": true,
-        "contexts": [],
         "checks": [
           { "context": "Gate Integrity Sentinel", "app_id": 15368 },
           { "context": "Universal PR Gate", "app_id": 15368 }
@@ -68,12 +79,10 @@
       },
       "enforce_admins": true,
       "required_pull_request_reviews": {
-        "dismissal_restrictions": {},
         "dismiss_stale_reviews": true,
         "require_code_owner_reviews": false,
         "required_approving_review_count": 1,
-        "require_last_push_approval": true,
-        "bypass_pull_request_allowances": {}
+        "require_last_push_approval": true
       },
       "restrictions": null,
       "required_conversation_resolution": true,

--- a/scripts/governance/validate-f2-gov-03.mjs
+++ b/scripts/governance/validate-f2-gov-03.mjs
@@ -4,6 +4,8 @@ import { pathToFileURL } from "node:url";
 import { readFile } from "node:fs/promises";
 
 const EXPECTED_BASE = "3fd31e615a8914aaa1b1d7bcb0a093222eb678ce";
+const EXPECTED_COMPATIBILITY_BASE = "32e63a416793a2ba0ca917d71ec652cc6bc22deb";
+const EXPECTED_API_VERSION = "2022-11-28";
 const EXPECTED_CHECKS = [
   { name:"Gate Integrity Sentinel", workflow:"Gate Integrity Sentinel", event:"pull_request_target", appId:15368, appSlug:"github-actions" },
   { name:"Universal PR Gate", workflow:"Universal PR Gate Candidate", event:"pull_request", appId:15368, appSlug:"github-actions" },
@@ -18,6 +20,84 @@ const EXPECTED_HASHES = {
 const equal = (actual, expected, message) => assert.deepEqual(actual, expected, message);
 const ok = (value, message) => assert.ok(value, message);
 const hash = (value) => createHash("sha256").update(JSON.stringify(value)).digest("hex");
+const EXPECTED_API_CHECKS = EXPECTED_CHECKS.map(({ name, appId }) => ({ context:name, app_id:appId }));
+const PERSONAL_REVIEW_KEYS = [
+  "dismiss_stale_reviews",
+  "require_code_owner_reviews",
+  "require_last_push_approval",
+  "required_approving_review_count",
+];
+const PERSONAL_PAYLOAD_KEYS = [
+  "allow_deletions",
+  "allow_force_pushes",
+  "allow_fork_syncing",
+  "block_creations",
+  "enforce_admins",
+  "lock_branch",
+  "required_conversation_resolution",
+  "required_linear_history",
+  "required_pull_request_reviews",
+  "required_status_checks",
+  "restrictions",
+];
+
+function rejectOrganizationCollections(value, location = "apiPayload") {
+  if (!value || typeof value !== "object") return;
+  for (const [key, child] of Object.entries(value)) {
+    ok(key !== "dismissal_restrictions", `organization-only field forbidden: ${location}.${key}`);
+    ok(key !== "bypass_pull_request_allowances", `organization-only field forbidden: ${location}.${key}`);
+    ok(!["users", "teams", "apps"].includes(key), `organization-only collection forbidden: ${location}.${key}`);
+    rejectOrganizationCollections(child, `${location}.${key}`);
+  }
+}
+
+export function validatePersonalAccountPayload(payload) {
+  ok(payload && typeof payload === "object" && !Array.isArray(payload), "personal-account payload must be an object");
+  rejectOrganizationCollections(payload);
+  equal(Object.keys(payload).sort(), PERSONAL_PAYLOAD_KEYS, "personal-account payload contains unknown or missing top-level fields");
+  const checks = payload.required_status_checks;
+  equal(Object.keys(checks ?? {}).sort(), ["checks", "strict"], "app-bound status checks must contain only strict and checks");
+  equal(checks.strict, true, "latest base requirement missing");
+  equal(checks.checks, EXPECTED_API_CHECKS, "API payload required checks mismatch");
+  for (const check of checks.checks) {
+    ok(Number.isInteger(check.app_id) && check.app_id === 15368, `required check app_id invalid: ${check.context ?? "unknown"}`);
+  }
+  equal(payload.enforce_admins, true, "administrators must remain protected");
+  const reviews = payload.required_pull_request_reviews;
+  equal(Object.keys(reviews ?? {}).sort(), PERSONAL_REVIEW_KEYS, "personal-account review payload contains unsupported restrictions or bypass");
+  equal(reviews.required_approving_review_count, 1, "approval requirement cannot be reduced");
+  equal(reviews.dismiss_stale_reviews, true, "stale approvals must be dismissed");
+  equal(reviews.require_last_push_approval, true, "last-push approval must remain required");
+  equal(reviews.require_code_owner_reviews, false, "code-owner review policy changed");
+  equal(payload.restrictions, null, "top-level push restrictions must remain null for a personal repository");
+  equal(payload.required_conversation_resolution, true, "conversation resolution must remain required");
+  equal(payload.required_linear_history, false, "normal merge requires non-linear history");
+  equal(payload.allow_force_pushes, false, "force pushes must remain blocked");
+  equal(payload.allow_deletions, false, "branch deletion must remain blocked");
+  equal(payload.block_creations, false, "branch creation policy changed");
+  equal(payload.lock_branch, false, "branch lock policy changed");
+  equal(payload.allow_fork_syncing, false, "fork sync policy changed");
+  return true;
+}
+
+export function validatePersonalAccountReadback(readback) {
+  ok(readback && typeof readback === "object" && !Array.isArray(readback), "personal-account readback must be an object");
+  rejectOrganizationCollections(readback, "readback");
+  equal(readback.required_status_checks?.strict, true, "readback strict checks mismatch");
+  equal(readback.required_status_checks?.checks, EXPECTED_API_CHECKS, "readback required checks mismatch");
+  equal(readback.enforce_admins?.enabled, true, "readback administrators are not protected");
+  const reviews = readback.required_pull_request_reviews;
+  ok(!Object.hasOwn(reviews ?? {}, "dismissal_restrictions"), "readback contains organization dismissal restrictions");
+  ok(!Object.hasOwn(reviews ?? {}, "bypass_pull_request_allowances"), "readback contains review bypass allowances");
+  equal(reviews?.required_approving_review_count, 1, "readback approval requirement mismatch");
+  equal(reviews?.dismiss_stale_reviews, true, "readback stale approval policy mismatch");
+  equal(reviews?.require_last_push_approval, true, "readback last-push policy mismatch");
+  equal(readback.restrictions, null, "readback top-level restrictions must be null");
+  equal(readback.required_conversation_resolution?.enabled, true, "readback conversation policy mismatch");
+  equal(readback.allow_force_pushes?.enabled, false, "readback force-push policy mismatch");
+  equal(readback.allow_deletions?.enabled, false, "readback deletion policy mismatch");
+  return true;
+}
 
 export function canonicalProposalView(proposal) {
   return {
@@ -32,6 +112,7 @@ export function canonicalProposalView(proposal) {
       rules:proposal.target.rules,
       bypass:proposal.target.bypass,
       mergePolicy:proposal.target.mergePolicy,
+      apiCompatibility:proposal.target.apiCompatibility,
       apiPayload:proposal.target.apiPayload,
     },
     gateEvolution:{
@@ -121,14 +202,23 @@ export function validateProposal(proposal) {
   equal(proposal.target.bypass.agentsAllowed, false, "agents cannot bypass protection");
   equal(proposal.target.bypass.breakGlassRequiresSeparateHumanDecision, true, "break-glass requires a separate human decision");
   const payload = proposal.target.apiPayload;
-  equal(payload.required_status_checks?.strict, true, "latest base requirement missing");
-  equal(payload.required_status_checks?.contexts, [], "legacy check contexts forbidden");
-  equal(payload.required_status_checks?.checks, EXPECTED_CHECKS.map(({ name, appId }) => ({ context:name, app_id:appId })), "API payload required checks mismatch");
+  equal(proposal.target.apiCompatibility, {
+    ownerType:"User",
+    apiVersion:EXPECTED_API_VERSION,
+    measuredAtBase:EXPECTED_COMPATIBILITY_BASE,
+    evidenceIssue:40,
+    incompatibleRequestFields:[
+      "required_status_checks.contexts with app-bound checks",
+      "required_pull_request_reviews.dismissal_restrictions",
+      "required_pull_request_reviews.bypass_pull_request_allowances",
+    ],
+    omissionSemantics:"No user, team, app or bypass allowance is granted; omitted organization-only fields are absent permissions.",
+  }, "personal-account API compatibility contract mismatch");
+  validatePersonalAccountPayload(payload);
   equal(payload.enforce_admins, rules.includeAdministrators, "API payload administrator mismatch");
   equal(payload.required_pull_request_reviews?.required_approving_review_count, rules.recommendedApprovals, "API payload approval count mismatch");
   equal(payload.required_pull_request_reviews?.dismiss_stale_reviews, true, "API payload stale approval mismatch");
   equal(payload.required_pull_request_reviews?.require_last_push_approval, true, "API payload last-push approval mismatch");
-  equal(payload.required_pull_request_reviews?.bypass_pull_request_allowances, {}, "API payload review bypass must be empty");
   equal(payload.required_conversation_resolution, true, "API payload conversation resolution mismatch");
   equal(payload.required_linear_history, false, "normal merge requires non-linear history");
   equal(payload.allow_force_pushes, false, "force pushes must remain blocked");

--- a/tests/audit/f2-gov-03.test.mjs
+++ b/tests/audit/f2-gov-03.test.mjs
@@ -37,6 +37,63 @@ test("proposal is exact, offline, merge-commit compatible and not active", async
   assert.equal(proposal.activation.authorized, false);
 });
 
+test("personal-account payload uses the app-bound schema without organization restrictions", async () => {
+  const [{ validatePersonalAccountPayload, validatePersonalAccountReadback }, proposal] = await Promise.all([loadValidator(), readJson(proposalPath)]);
+  const payload = proposal.target.apiPayload;
+  assert.equal(validatePersonalAccountPayload(payload), true);
+  assert.deepEqual(Object.keys(payload.required_status_checks).sort(), ["checks", "strict"]);
+  assert.equal("contexts" in payload.required_status_checks, false);
+  assert.equal("dismissal_restrictions" in payload.required_pull_request_reviews, false);
+  assert.equal("bypass_pull_request_allowances" in payload.required_pull_request_reviews, false);
+  assert.equal(payload.restrictions, null);
+  const readback = {
+    required_status_checks: structuredClone(payload.required_status_checks),
+    enforce_admins:{ enabled:true },
+    required_pull_request_reviews:structuredClone(payload.required_pull_request_reviews),
+    restrictions:null,
+    required_conversation_resolution:{ enabled:true },
+    allow_force_pushes:{ enabled:false },
+    allow_deletions:{ enabled:false },
+  };
+  assert.equal(validatePersonalAccountReadback(readback), true);
+});
+
+test("personal-account payload rejects incompatible schema and security regressions", async (t) => {
+  const { validatePersonalAccountPayload } = await loadValidator();
+  const proposal = await readJson(proposalPath);
+  const cases = [
+    ["contexts beside app-bound checks", (p) => { p.required_status_checks.contexts = []; }, "app-bound status checks must contain only strict and checks"],
+    ["contexts without checks", (p) => { p.required_status_checks = { strict:true, contexts:[] }; }, "app-bound status checks must contain only strict and checks"],
+    ["app id absent", (p) => { delete p.required_status_checks.checks[0].app_id; }, "API payload required checks mismatch"],
+    ["app id altered", (p) => { p.required_status_checks.checks[0].app_id = 42; }, "API payload required checks mismatch"],
+    ["app id invalid", (p) => { p.required_status_checks.checks[0].app_id = "15368"; }, "API payload required checks mismatch"],
+    ["check extra", (p) => { p.required_status_checks.checks.push({ context:"Extra", app_id:15368 }); }, "API payload required checks mismatch"],
+    ["check absent", (p) => { p.required_status_checks.checks.pop(); }, "API payload required checks mismatch"],
+    ["check duplicated", (p) => { p.required_status_checks.checks.push(structuredClone(p.required_status_checks.checks[0])); }, "API payload required checks mismatch"],
+    ["check renamed", (p) => { p.required_status_checks.checks[0].context += " Candidate"; }, "API payload required checks mismatch"],
+    ["dismissal restrictions empty", (p) => { p.required_pull_request_reviews.dismissal_restrictions = {}; }, "organization-only field forbidden"],
+    ["dismissal restrictions populated", (p) => { p.required_pull_request_reviews.dismissal_restrictions = { users:["actor"] }; }, "organization-only field forbidden"],
+    ["bypass allowances empty", (p) => { p.required_pull_request_reviews.bypass_pull_request_allowances = {}; }, "organization-only field forbidden"],
+    ["bypass allowances populated", (p) => { p.required_pull_request_reviews.bypass_pull_request_allowances = { apps:["app"] }; }, "organization-only field forbidden"],
+    ["top-level dismissal restrictions", (p) => { p.dismissal_restrictions = {}; }, "organization-only field forbidden"],
+    ["top-level bypass allowances", (p) => { p.bypass_pull_request_allowances = {}; }, "organization-only field forbidden"],
+    ["users collection", (p) => { p.users = []; }, "organization-only collection forbidden"],
+    ["teams collection", (p) => { p.teams = []; }, "organization-only collection forbidden"],
+    ["apps collection", (p) => { p.apps = []; }, "organization-only collection forbidden"],
+    ["organization restrictions object", (p) => { p.restrictions = { users:[], teams:[], apps:[] }; }, "organization-only collection forbidden"],
+    ["administrator exemption", (p) => { p.enforce_admins = false; }, "administrators must remain protected"],
+    ["approval reduction", (p) => { p.required_pull_request_reviews.required_approving_review_count = 0; }, "approval requirement cannot be reduced"],
+    ["stale reviews retained", (p) => { p.required_pull_request_reviews.dismiss_stale_reviews = false; }, "stale approvals must be dismissed"],
+    ["force push allowed", (p) => { p.allow_force_pushes = true; }, "force pushes must remain blocked"],
+    ["deletion allowed", (p) => { p.allow_deletions = true; }, "branch deletion must remain blocked"],
+  ];
+  for (const [label, mutate, expected] of cases) await t.test(label, () => {
+    const payload = structuredClone(proposal.target.apiPayload);
+    mutate(payload);
+    assert.throws(() => validatePersonalAccountPayload(payload), (error) => error.message.includes(expected));
+  });
+});
+
 test("document, fixture and proposed API payload remain structurally identical", async () => {
   const [{ canonicalProposalView, extractDocumentContract }, proposal, document] = await Promise.all([
     loadValidator(), readJson(proposalPath), read(documentPath),
@@ -87,10 +144,10 @@ test("proposal negatives fail closed for security, lockout and provenance regres
     ["permanent bypass", (p) => { p.target.bypass.permanent = true; }, "permanent bypass forbidden"],
     ["agent bypass", (p) => { p.target.bypass.agentsAllowed = true; }, "agents cannot bypass protection"],
     ["break-glass implicit", (p) => { p.target.bypass.breakGlassRequiresSeparateHumanDecision = false; }, "break-glass requires a separate human decision"],
-    ["API review bypass", (p) => { p.target.apiPayload.required_pull_request_reviews.bypass_pull_request_allowances = { users:["attacker"] }; }, "API payload review bypass must be empty"],
+    ["API review bypass", (p) => { p.target.apiPayload.required_pull_request_reviews.bypass_pull_request_allowances = { users:["attacker"] }; }, "organization-only field forbidden"],
     ["admin silently exempt", (p) => { p.target.rules.includeAdministrators = false; }, "administrator decision cannot be silently exempt"],
     ["force push allowed", (p) => { p.target.apiPayload.allow_force_pushes = true; }, "force pushes must remain blocked"],
-    ["deletion allowed", (p) => { p.target.apiPayload.allow_deletions = true; }, "main deletion must remain blocked"],
+    ["deletion allowed", (p) => { p.target.apiPayload.allow_deletions = true; }, "branch deletion must remain blocked"],
     ["linear history enabled", (p) => { p.target.apiPayload.required_linear_history = true; }, "normal merge requires non-linear history"],
     ["normal merge removed", (p) => { p.target.mergePolicy.recommendedMethods = ["squash"]; }, "normal merge must remain compatible"],
     ["lockout trial absent", (p) => { p.activation.stageOneDisposableTrial.required = false; }, "disposable pre-activation trial required"],


### PR DESCRIPTION
## Escopo

Correção estritamente offline do payload candidato F2-GOV-03 para o esquema real da API GitHub em repositório de conta pessoal. Issue-lock: #41. Base: `32e63a416793a2ba0ca917d71ec652cc6bc22deb`.

## RED reproduzido

- O validador anterior aceitou `required_status_checks` com `contexts: []` e `checks` vinculados por `app_id` simultaneamente.
- O payload anterior produziu `dismissal_restrictions: {}` e `bypass_pull_request_allowances: {}`.
- As duas formas correspondem aos HTTP 422 reais registados na Issue #40.
- O novo teste falhou inicialmente porque o contrato de conta pessoal ainda não existia.

## GREEN

- `required_status_checks` contém exclusivamente `strict` e os dois `checks` aprovados, ambos com `app_id: 15368`.
- Campos organizacionais de dismissal/bypass e quaisquer coleções `users`/`teams`/`apps` são proibidos recursivamente.
- `restrictions: null` permanece como campo de topo do endpoint, sem inventar restrições organizacionais.
- Administradores, uma aprovação, stale dismissal, last-push approval, conversas, bloqueio de force-push e bloqueio de eliminação permanecem vinculativos.
- A leitura esperada da API também é validada sem bypass.

## Evidência local

- F2-GOV-03: 72/72.
- Contrato integrado: 131/131.
- Todas as suítes de auditoria/governança: 330/330.
- Proteção de deploy/payload: 13/13; payload continua com 56 ficheiros.
- Matriz DOM: 60/60.
- Evidência visual: 13 ACCEPT; controlo negativo REJECT.
- JSON e YAML válidos; `git diff --check` limpo.

## Diff

Cinco ficheiros: proposta e handoff F2-GOV-03, fixture canónica, validador e teste. Zero HTML, CSS, JavaScript, assets vivos, workflows, deploy ou manifesto de publicação.

## Segurança e limites

Este pacote **não aplica proteção**. Não executou PUT/DELETE de branch protection, ruleset, required check, FTP, `workflow_dispatch`, deployment, secret ou produção. Via B permanece obrigatória. O próximo passo possível é somente um novo ensaio descartável com autorização própria.

## Risco e rollback

Risco residual: o payload corrigido ainda precisa de novo ensaio real descartável; capacidades de conta e bypass de ator continuam NOT_VERIFIED até esse ensaio. Rollback após eventual merge autorizado: `git revert -m 1 <merge_sha>`.
